### PR TITLE
Swapping order of R and G LEDs, using board defined pins.

### DIFF
--- a/adafruit_is31fl3731.py
+++ b/adafruit_is31fl3731.py
@@ -504,7 +504,7 @@ class Keybow2040(Matrix):
         :param blink: True to blink
         :param frame: the frame to set the pixel
         """
-        x = x + (4 * y)
+        x = 15 - (x + (4 * y))
 
         super().pixel(x, 0, g, blink, frame)
         super().pixel(x, 1, r, blink, frame)

--- a/adafruit_is31fl3731.py
+++ b/adafruit_is31fl3731.py
@@ -506,8 +506,8 @@ class Keybow2040(Matrix):
         """
         x = x + (4 * y)
 
-        super().pixel(x, 0, r, blink, frame)
-        super().pixel(x, 1, g, blink, frame)
+        super().pixel(x, 0, g, blink, frame)
+        super().pixel(x, 1, r, blink, frame)
         super().pixel(x, 2, b, blink, frame)
 
         # pylint: disable=inconsistent-return-statements

--- a/adafruit_is31fl3731.py
+++ b/adafruit_is31fl3731.py
@@ -504,7 +504,7 @@ class Keybow2040(Matrix):
         :param blink: True to blink
         :param frame: the frame to set the pixel
         """
-        x = 15 - (x + (4 * y))
+        x = (4 * (3 - x)) + y
 
         super().pixel(x, 0, g, blink, frame)
         super().pixel(x, 1, r, blink, frame)

--- a/examples/is31fl3731_keybow_2040_rainbow.py
+++ b/examples/is31fl3731_keybow_2040_rainbow.py
@@ -18,7 +18,6 @@ Author(s): Sandy Macdonald.
 import time
 import math
 import board
-import busio
 
 import adafruit_is31fl3731
 
@@ -62,7 +61,7 @@ def hsv_to_rgb(hue, sat, val):
         return (val, p, q)
 
 
-i2c = busio.I2C(board.I2C())
+i2c = board.I2C()
 
 # Set up 4x4 RGB matrix of Keybow 2040
 display = adafruit_is31fl3731.Keybow2040(i2c)

--- a/examples/is31fl3731_keybow_2040_rainbow.py
+++ b/examples/is31fl3731_keybow_2040_rainbow.py
@@ -62,7 +62,7 @@ def hsv_to_rgb(hue, sat, val):
         return (val, p, q)
 
 
-i2c = busio.I2C(board.GP5, board.GP4)
+i2c = busio.I2C(board.I2C())
 
 # Set up 4x4 RGB matrix of Keybow 2040
 display = adafruit_is31fl3731.Keybow2040(i2c)


### PR DESCRIPTION
The final hardware swaps the order of the red and green LED elements, so this PR reflects that. I've also updated the rainbow example to use `board.I2C()` when setting up the I2C bus as there are board definitions for the Pimoroni RP2040 boards in CircuitPython now!