### PR TITLE
Make example better/ready for Pico & 11x7 LED Matrix Breakout

### DIFF
--- a/examples/is31fl3731_blink_example.py
+++ b/examples/is31fl3731_blink_example.py
@@ -26,6 +26,8 @@ an_arrow = bytearray((0x08, 0x0C, 0xFE, 0xFF, 0xFE, 0x0C, 0x08, 0x00, 0x00))
 
 display = Display(i2c)
 
+offset = (display.width - 8)//2
+
 # first load the frame with the arrows; moves the an_arrow to the right in each
 # frame
 display.sleep(True)  # turn display off while updating blink bits
@@ -35,7 +37,7 @@ for y in range(display.height):
     for x in range(8):
         bit = 1 << (7 - x) & row
         if bit:
-            display.pixel(x + 4, y, 50, blink=True)
+            display.pixel(x + offset, y, 50, blink=True)
 
 display.blink(1000)  # ranges from 270 to 2159; smaller the number to faster blink
 display.sleep(False)  # turn display on

--- a/examples/is31fl3731_blink_example.py
+++ b/examples/is31fl3731_blink_example.py
@@ -13,6 +13,11 @@ from adafruit_is31fl3731.charlie_wing import CharlieWing as Display
 # from adafruit_is31fl3731.charlie_bonnet import CharlieBonnet as Display
 # uncomment next line if you are using Pimoroni Scroll Phat HD LED 17 x 7
 # from adafruit_is31fl3731.scroll_phat_hd import ScrollPhatHD as Display
+# uncomment next line if you are using Pimoroni 11x7 LED Matrix Breakout
+# from adafruit_is31fl3731.matrix_11x7 import Matrix11x7 as Display
+
+# uncomment this line if you use a Pico, here with SCL=GP21 and SDA=GP20.
+# i2c = busio.I2C(board.GP21, board.GP20)
 
 i2c = busio.I2C(board.SCL, board.SDA)
 

--- a/examples/is31fl3731_blink_example.py
+++ b/examples/is31fl3731_blink_example.py
@@ -26,7 +26,7 @@ an_arrow = bytearray((0x08, 0x0C, 0xFE, 0xFF, 0xFE, 0x0C, 0x08, 0x00, 0x00))
 
 display = Display(i2c)
 
-offset = (display.width - 8)//2
+offset = (display.width - 8) // 2
 
 # first load the frame with the arrows; moves the an_arrow to the right in each
 # frame

--- a/examples/is31fl3731_frame_example.py
+++ b/examples/is31fl3731_frame_example.py
@@ -31,7 +31,7 @@ display = Display(i2c)
 # first load the frame with the arrows; moves the arrow to the right in each
 # frame
 display.sleep(True)  # turn display off while frames are updated
-for frame in range(8):
+for frame in range(display.width-8):
     display.frame(frame, show=False)
     display.fill(0)
     for y in range(display.height):

--- a/examples/is31fl3731_frame_example.py
+++ b/examples/is31fl3731_frame_example.py
@@ -27,11 +27,10 @@ arrow = bytearray((0x08, 0x0C, 0xFE, 0xFF, 0xFE, 0x0C, 0x08, 0x00, 0x00))
 
 display = Display(i2c)
 
-
 # first load the frame with the arrows; moves the arrow to the right in each
 # frame
 display.sleep(True)  # turn display off while frames are updated
-for frame in range(display.width-8):
+for frame in range(display.width - 8):
     display.frame(frame, show=False)
     display.fill(0)
     for y in range(display.height):

--- a/examples/is31fl3731_frame_example.py
+++ b/examples/is31fl3731_frame_example.py
@@ -14,6 +14,11 @@ from adafruit_is31fl3731.charlie_wing import CharlieWing as Display
 # from adafruit_is31fl3731.charlie_bonnet import CharlieBonnet as Display
 # uncomment next line if you are using Pimoroni Scroll Phat HD LED 17 x 7
 # from adafruit_is31fl3731.scroll_phat_hd import ScrollPhatHD as Display
+# uncomment next line if you are using Pimoroni 11x7 LED Matrix Breakout
+# from adafruit_is31fl3731.matrix_11x7 import Matrix11x7 as Display
+
+# uncomment this line if you use a Pico, here with SCL=GP21 and SDA=GP20.
+# i2c = busio.I2C(board.GP21, board.GP20)
 
 i2c = busio.I2C(board.SCL, board.SDA)
 

--- a/examples/is31fl3731_simpletest.py
+++ b/examples/is31fl3731_simpletest.py
@@ -13,6 +13,11 @@ from adafruit_is31fl3731.charlie_wing import CharlieWing as Display
 # from adafruit_is31fl3731.charlie_bonnet import CharlieBonnet as Display
 # uncomment next line if you are using Pimoroni Scroll Phat HD LED 17 x 7
 # from adafruit_is31fl3731.scroll_phat_hd import ScrollPhatHD as Display
+# uncomment next line if you are using Pimoroni 11x7 LED Matrix Breakout
+# from adafruit_is31fl3731.matrix_11x7 import Matrix11x7 as Display
+
+# uncomment this line if you use a Pico, here with SCL=GP21 and SDA=GP20.
+# i2c = busio.I2C(board.GP21, board.GP20)
 
 i2c = busio.I2C(board.SCL, board.SDA)
 

--- a/examples/is31fl3731_text_example.py
+++ b/examples/is31fl3731_text_example.py
@@ -14,6 +14,11 @@ from adafruit_is31fl3731.charlie_bonnet import CharlieBonnet as Display
 
 # uncomment next line if you are using Pimoroni Scroll Phat HD LED 17 x 7
 # from adafruit_is31fl3731.scroll_phat_hd import ScrollPhatHD as Display
+# uncomment next line if you are using Pimoroni 11x7 LED Matrix Breakout
+# from adafruit_is31fl3731.matrix_11x7 import Matrix11x7 as Display
+
+# uncomment this line if you use a Pico, here with SCL=GP21 and SDA=GP20.
+# i2c = busio.I2C(board.GP21, board.GP20)
 
 i2c = busio.I2C(board.SCL, board.SDA)
 

--- a/examples/is31fl3731_wave_example.py
+++ b/examples/is31fl3731_wave_example.py
@@ -13,6 +13,11 @@ from adafruit_is31fl3731.charlie_wing import CharlieWing as Display
 # from adafruit_is31fl3731.charlie_bonnet import CharlieBonnet as Display
 # uncomment next line if you are using Pimoroni Scroll Phat HD LED 17 x 7
 # from adafruit_is31fl3731.scroll_phat_hd import ScrollPhatHD as Display
+# uncomment next line if you are using Pimoroni 11x7 LED Matrix Breakout
+# from adafruit_is31fl3731.matrix_11x7 import Matrix11x7 as Display
+
+# uncomment this line if you use a Pico, here with SCL=GP21 and SDA=GP20.
+# i2c = busio.I2C(board.GP21, board.GP20)
 
 i2c = busio.I2C(board.SCL, board.SDA)
 


### PR DESCRIPTION
Add hint (comment) for using example with Pico and Pimoroni 11x7 LED Matrix Breakout.

1) Pico does not have dedicated pin of I2C, but many board use SCL=GP21 and SDA=GP20
2) Two example assume the width is 15, 16 or 17 but do not look good/centered with a width of 11

( tested with Scroll pHAT HD (17x7) both normal driver but also forcing "width = 11" to see the effect on smaller matrix )