### PR TITLE
5x5 breakout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ This driver supports the following hardware:
 * `Pimoroni 17x7 Scroll pHAT HD <https://www.adafruit.com/product/3473>`_
 * `Pimoroni 28x3 (r,g,b) Led Shim <https://www.adafruit.com/product/3831>`_
 * `Pimoroni Keybow 2040 with 4x4 matrix of RGB LEDs <https://shop.pimoroni.com/products/keybow-2040>`_
+* `Pimoroni 5x5 RGB Matrix Breakout https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout`_
 
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ This driver supports the following hardware:
 * `Pimoroni 17x7 Scroll pHAT HD <https://www.adafruit.com/product/3473>`_
 * `Pimoroni 28x3 (r,g,b) Led Shim <https://www.adafruit.com/product/3831>`_
 * `Pimoroni Keybow 2040 with 4x4 matrix of RGB LEDs <https://shop.pimoroni.com/products/keybow-2040>`_
-* `Pimoroni 5x5 RGB Matrix Breakout https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout`_
+* `Pimoroni 5x5 RGB Matrix Breakout <https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout>`_
 
 
 Dependencies

--- a/adafruit_is31fl3731/rgbmatrix5x5.py
+++ b/adafruit_is31fl3731/rgbmatrix5x5.py
@@ -63,7 +63,7 @@ class RGBmatrix5x5(IS31FL3731):
 
     @staticmethod
     def pixel_addr(x, y):
-
+        # pylint: disable=duplicate-code
         lookup = [
             (118, 69, 85),
             (117, 68, 101),

--- a/adafruit_is31fl3731/rgbmatrix5x5.py
+++ b/adafruit_is31fl3731/rgbmatrix5x5.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Tony DiCola 2017 for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_is31fl3731.RGBmatrix5x5`
+====================================================
+
+CircuitPython driver for the IS31FL3731 charlieplex IC.
+
+
+* Author(s): Tony DiCola, Melissa LeBlanc-Williams, David Glaude
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `5x5 RGB Matrix Breakout
+  <https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout>`_
+
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+# imports
+from . import IS31FL3731
+
+
+class RGBmatrix5x5(IS31FL3731):
+    """Supports the Pimoroni RGBmatrix5x5 with 5x5 matrix of RGB LEDs """
+
+    width = 25
+    height = 3
+
+    # pylint: disable=too-many-arguments
+
+    def pixelrgb(self, x, y, r, g, b, blink=None, frame=None):
+        """
+        Blink or brightness for x, y-pixel
+
+        :param x: horizontal pixel position
+        :param y: vertical pixel position
+        :param r: red brightness value 0->255
+        :param g: green brightness value 0->255
+        :param b: blue brightness value 0->255
+        :param blink: True to blink
+        :param frame: the frame to set the pixel
+        """
+        x = (4 * (3 - x)) + y
+
+        super().pixel(x, 0, g, blink, frame)
+        super().pixel(x, 1, r, blink, frame)
+        super().pixel(x, 2, b, blink, frame)
+
+        # pylint: disable=inconsistent-return-statements
+        # pylint: disable=too-many-return-statements
+        # pylint: disable=too-many-branches
+
+    @staticmethod
+    def pixel_addr(x, y):
+
+        lookup = [
+            (118, 69, 85),
+            (117, 68, 101),
+            (116, 84, 100),
+            (115, 83, 99),
+            (114, 82, 98),
+            (113, 81, 97),
+            (112, 80, 96),
+            (134, 21, 37),
+            (133, 20, 36),
+            (132, 19, 35),
+            (131, 18, 34),
+            (130, 17, 50),
+            (129, 33, 49),
+            (128, 32, 48),
+            (127, 47, 63),
+            (121, 41, 57),
+            (122, 25, 58),
+            (123, 26, 42),
+            (124, 27, 43),
+            (125, 28, 44),
+            (126, 29, 45),
+            (15, 95, 111),
+            (8, 89, 105),
+            (9, 90, 106),
+            (10, 91, 107),
+            (11, 92, 108),
+            (12, 76, 109),
+            (13, 77, 93),
+        ]
+
+        return lookup[x][y]

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -47,11 +47,17 @@ libraries. CircuitPython does not support PIL/pillow (python imaging library)!
     :caption: examples/is31fl3731_pillow_numbers.py
     :linenos:
 
-Led Shim Example
-----------------
+Colorfull Examples
+------------------
 
 Example that work on the RGB Led Shim.
 
 .. literalinclude:: ../examples/is31fl3731_ledshim_rainbow.py
     :caption: examples/is31fl3731_ledshim_rainbow.py
+    :linenos:
+
+Example that work on the RGB Matrix 5x5.
+
+.. literalinclude:: ../examples/is31fl3731_RGBmatrix5x5_rainbow.py
+    :caption: examples/is31fl3731_RGBmatrix5x5_rainbow.py
     :linenos:

--- a/examples/is31fl3731_RGBmatrix5x5_rainbow.py
+++ b/examples/is31fl3731_RGBmatrix5x5_rainbow.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2021 Sandy Macdonald, David Glaude
+# SPDX-License-Identifier: MIT
+
+"""
+Example to display a rainbow animation on the 5x5 RGB Matrix Breakout.
+
+Usage:
+Rename this file code.py and pop it on your Raspberry Pico's
+CIRCUITPY drive.
+
+This example is for use on the Pico Explorer Base or other board that use the same SDA/SCL pin.
+
+Author(s): Sandy Macdonald, David Glaude.
+"""
+
+import time
+import math
+import board
+
+from adafruit_is31fl3731.RGBmatrix5x5 import RGBmatrix5x5 as Display
+
+# pylint: disable=inconsistent-return-statements
+# pylint: disable=too-many-return-statements
+# pylint: disable=invalid-name
+
+
+def hsv_to_rgb(hue, sat, val):
+    """
+    Convert HSV colour to RGB
+
+    :param hue: hue; 0.0-1.0
+    :param sat: saturation; 0.0-1.0
+    :param val: value; 0.0-1.0
+    """
+
+    if sat == 0.0:
+        return (val, val, val)
+
+    i = int(hue * 6.0)
+
+    p = val * (1.0 - sat)
+    f = (hue * 6.0) - i
+    q = val * (1.0 - sat * f)
+    t = val * (1.0 - sat * (1.0 - f))
+
+    i %= 6
+
+    if i == 0:
+        return (val, t, p)
+    if i == 1:
+        return (q, val, p)
+    if i == 2:
+        return (p, val, t)
+    if i == 3:
+        return (p, q, val)
+    if i == 4:
+        return (t, p, val)
+    if i == 5:
+        return (val, p, q)
+
+
+# Create the I2C bus on a Pico Explorer Base
+i2c = busio.I2C(board.GP21, board.GP20)
+
+# Set up 5x5 RGB matrix Breakout
+display = adafruit_is31fl3731.RGBmatrix5x5(i2c)
+
+step = 0
+
+while True:
+    step += 1
+    for y in range(0, 5):
+        for x in range(0, 5):
+            pixel_hue = (x + y + (step / 20)) / 8
+            pixel_hue = pixel_hue - int(pixel_hue)
+            pixel_hue += 0
+            pixel_hue = pixel_hue - math.floor(pixel_hue)
+
+            rgb = hsv_to_rgb(pixel_hue, 1, 1)
+
+            display.pixelrgb(
+                x, y, int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255)
+            )
+
+    time.sleep(0.01)

--- a/examples/is31fl3731_RGBmatrix5x5_rainbow.py
+++ b/examples/is31fl3731_RGBmatrix5x5_rainbow.py
@@ -15,6 +15,7 @@ Author(s): Sandy Macdonald, David Glaude.
 
 import time
 import math
+import busio
 import board
 
 from adafruit_is31fl3731.RGBmatrix5x5 import RGBmatrix5x5 as Display
@@ -63,7 +64,28 @@ def hsv_to_rgb(hue, sat, val):
 i2c = busio.I2C(board.GP21, board.GP20)
 
 # Set up 5x5 RGB matrix Breakout
-display = adafruit_is31fl3731.RGBmatrix5x5(i2c)
+display = Display(i2c)
+
+for y in range(0, 5):
+    for x in range(0, 5):
+        display.pixelrgb(x, y, 255, 0, 0)
+        time.sleep(0.1)
+
+time.sleep(0.5)
+
+for y in range(0, 5):
+    for x in range(0, 5):
+        display.pixelrgb(x, y, 0, 255, 0)
+        time.sleep(0.1)
+
+time.sleep(0.5)
+
+for y in range(0, 5):
+    for x in range(0, 5):
+        display.pixelrgb(x, y, 0, 0, 255)
+        time.sleep(0.1)
+
+time.sleep(0.5)
 
 step = 0
 


### PR DESCRIPTION
This is not tested on the real hardware, so it has to be considered draft until this is tested.

Room for improvement:

- lookup table is the one from Pimoroni library, it has 3 unused entries (28 vs 25) but that is the same as upstream: https://github.com/pimoroni/rgbmatrix5x5-python/blob/7eed75c57604b2c8afc0bcb82ff0221f0ecbbd3f/library/rgbmatrix5x5/is31fl3731.py#L367
- lookup table can be replaced by computation as it was done in led_shim.py (memory vs cpu tradeof): https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3731/blob/11533d4827249ca33e8b9d5840f272494606688b/adafruit_is31fl3731/led_shim.py#L63

