### PR TITLE
Fixing RGB order on Keybow 2040, and fixing import in rainbow example.

### DIFF
--- a/adafruit_is31fl3731/keybow2040.py
+++ b/adafruit_is31fl3731/keybow2040.py
@@ -53,8 +53,8 @@ class Keybow2040(IS31FL3731):
         """
         x = (4 * (3 - x)) + y
 
-        super().pixel(x, 0, g, blink, frame)
-        super().pixel(x, 1, r, blink, frame)
+        super().pixel(x, 0, r, blink, frame)
+        super().pixel(x, 1, g, blink, frame)
         super().pixel(x, 2, b, blink, frame)
 
         # pylint: disable=inconsistent-return-statements

--- a/examples/is31fl3731_keybow_2040_rainbow.py
+++ b/examples/is31fl3731_keybow_2040_rainbow.py
@@ -19,7 +19,7 @@ import time
 import math
 import board
 
-import adafruit_is31fl3731
+from adafruit_is31fl3731.keybow2040 import Keybow2040 as Display
 
 # pylint: disable=inconsistent-return-statements
 # pylint: disable=too-many-return-statements
@@ -64,7 +64,7 @@ def hsv_to_rgb(hue, sat, val):
 i2c = board.I2C()
 
 # Set up 4x4 RGB matrix of Keybow 2040
-display = adafruit_is31fl3731.Keybow2040(i2c)
+display = Display(i2c)
 
 step = 0
 


### PR DESCRIPTION
Really sorry, but the production version of Keybow 2040 has changed the LED order back again!! I'm also updating the Keybow rainbow example to match the new method of importing the Display class.