### PR TITLE
A couple of speedups

### DIFF
--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -92,11 +92,11 @@ class IS31FL3731:
     width = 16
     height = 9
 
-    def __init__(self, i2c, address=0x74):
+    def __init__(self, i2c, address=0x74, frames=None):
         self.i2c = i2c
         self.address = address
         self._frame = None
-        self._init()
+        self._init(frames=frames)
 
     def _i2c_read_reg(self, reg, result):
         # Read a buffer of data from the specified 8-bit I2C register address.
@@ -111,18 +111,20 @@ class IS31FL3731:
             self.i2c.unlock()
         return None
 
-    def _i2c_write_reg(self, reg, data):
-        # Write a buffer of data (byte array) to the specified I2C register
-        # address.
+    def _i2c_write_block(self, data):
+        # Writes a contiguous block of data (bytearray) where the first byte
+        # is the starting I2C register address (register is not an argument).
         while not self.i2c.try_lock():
             pass
         try:
-            buf = bytearray(1)
-            buf[0] = reg
-            buf.extend(data)
-            self.i2c.writeto(self.address, buf)
+            self.i2c.writeto(self.address, data)
         finally:
             self.i2c.unlock()
+
+    def _i2c_write_reg(self, reg, data):
+        # Write a contiguous block of data (bytearray) starting at the
+        # specified I2C register address (register passed as argument).
+        self._i2c_write_block(bytes([reg]) + data)
 
     def _bank(self, bank=None):
         if bank is None:
@@ -142,16 +144,21 @@ class IS31FL3731:
     def _mode(self, mode=None):
         return self._register(_CONFIG_BANK, _MODE_REGISTER, mode)
 
-    def _init(self):
+    def _init(self, frames=None):
         self.sleep(True)
-        time.sleep(0.01)  # 10 MS pause to reset.
-        self._mode(_PICTURE_MODE)
-        self.frame(0)
-        for frame in range(8):
-            self.fill(0, False, frame=frame)
-            for col in range(18):
-                self._register(frame, _ENABLE_OFFSET + col, 0xFF)
-        self.audio_sync(False)
+        # Clear config; sets to Picture Mode, no audio sync, maintains sleep
+        self._bank(_CONFIG_BANK)
+        self._i2c_write_block(bytes([0] * 14))
+        enable_data = bytes([_ENABLE_OFFSET] + [255] * 18)
+        fill_data = bytearray([0] * 25)
+        # Initialize requested frames, or all 8 if unspecified
+        for frame in frames if frames else range(8):
+            self._bank(frame)
+            self._i2c_write_block(enable_data) # Set all enable bits
+            for row in range(6): # Barebones quick fill() w/0
+                fill_data[0] = _COLOR_OFFSET + row * 24
+                self._i2c_write_block(fill_data)
+        self._frame = 0  # To match config bytes above
         self.sleep(False)
 
     def reset(self):

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -154,8 +154,8 @@ class IS31FL3731:
         # Initialize requested frames, or all 8 if unspecified
         for frame in frames if frames else range(8):
             self._bank(frame)
-            self._i2c_write_block(enable_data) # Set all enable bits
-            for row in range(6): # Barebones quick fill() w/0
+            self._i2c_write_block(enable_data)  # Set all enable bits
+            for row in range(6):  # Barebones quick fill() w/0
                 fill_data[0] = _COLOR_OFFSET + row * 24
                 self._i2c_write_block(fill_data)
         self._frame = 0  # To match config bytes above


### PR DESCRIPTION
A current project requires high-speed (full-frame animated) updates on 8 matrices on Raspberry Pi, split across two buses, but currently only manages less than 2 FPS. Since “soft” I2C on Pi is limited to about 200 KHz max, we can’t just crank up the frequency to compensate, so instead this PR proposes a couple of speed improvements:

Applicable to **all devices**: _init() takes a direct approach to initializing all registers, rather than going through things like the fill() function. Additionally, this now accepts an optional frames= kwarg, which can reduce the initialization to only those frames an application anticipates using (e.g. if doing double-buffered animation, one might only need frames 0 and 1). The changes yield about a 2X speedup if all 8 frames are initialized, or 9X if using just 2 (e.g. frames=(0,1)). This might seem unnecessary, but across 8 matrices it really adds up. This change does require a couple dozen extra bytes, but I’d call it inconsequential, this is only on startup before the application really gets to business.

Applicable to the **Matrix** class only: image() similarly takes some direct action, rather than iterating through pixel() every time. Yields about a 6X speedup, getting a bit over 10 FPS across 8 matrices, just adequate to be considered animation. This does require a couple hundred bytes extra…but…since image() implies the use of PIL, it’s by definition not running on a RAM-constrained microcontroller, and might likewise be considered inconsequential.