### PR TITLE
Add adafruit_bus_device dependency

### DIFF
--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -109,11 +109,15 @@ class IS31FL3731:
         return None
 
     def _i2c_write_reg(self, reg, data):
+        # Write a contiguous block of data (bytearray) starting at the
+        # specified I2C register address (register passed as argument).
+        self._i2c_write_block(bytes([reg]) + data)
+
+    def _i2c_write_block(self, data):
         # Write a buffer of data (byte array) to the specified I2C register
         # address.
         with self.i2c_device as i2c:
             buf = bytearray(1)
-            buf[0] = reg
             buf.extend(data)
             i2c.write(buf)
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -278,14 +278,10 @@ class IS31FL3731:
             if not 0 <= color <= 255:
                 raise ValueError("Color out of range")
             data = bytearray([color] * 25)  # Extra byte at front for address.
-            while not self.i2c.try_lock():
-                pass
-            try:
+            with self.i2c_device as i2c:
                 for row in range(6):
                     data[0] = _COLOR_OFFSET + row * 24
-                    self.i2c.writeto(self.address, data)
-            finally:
-                self.i2c.unlock()
+                    i2c.write(data)
         if blink is not None:
             data = bool(blink) * 0xFF
             for col in range(18):

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -117,9 +117,7 @@ class IS31FL3731:
         # Write a buffer of data (byte array) to the specified I2C register
         # address.
         with self.i2c_device as i2c:
-            buf = bytearray(1)
-            buf.extend(data)
-            i2c.write(buf)
+            i2c.write(data)
 
     def _bank(self, bank=None):
         if bank is None:

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -87,8 +87,8 @@ class IS31FL3731:
     The IS31FL3731 is an abstract class contain the main function related to this chip.
     Each board needs to define width, height and pixel_addr.
 
-    :param ~adafruit_bus_device.i2c_device i2c_device: the connected i2c bus i2c_device
-    :param address: the device address; defaults to 0x74
+    :param ~busio.I2C i2c: the connected i2c bus i2c_device
+    :param int address: the device address; defaults to 0x74
     """
 
     width = 16

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-framebuf
+adafruit-circuitpython-busdevice

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=[
+        "Adafruit-Blinka",
+        "adafruit-circuitpython-busdevice",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
I debated trying to incorporate `adafruit_register` as well in a few different ways, but none of the exist classes do exactly what the library needs it seems, so I left that aspect as is.

Also adds some minor documentations additions.

Resolves #49 