### PR TITLE
Return from fade on "None"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _build
 # Virtual environment-specific files
 .env
 .venv
+venv
 
 # MacOS-specific files
 *.DS_Store

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -10,7 +10,7 @@ CircuitPython driver for the IS31FL3731 charlieplex IC.
 
 Base library.
 
-* Author(s): Tony DiCola, Melissa LeBlanc-Williams, David Glaude
+* Author(s): Tony DiCola, Melissa LeBlanc-Williams, David Glaude, E. A. Graham Jr.
 
 Implementation Notes
 --------------------

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -201,8 +201,9 @@ class IS31FL3731:
         :param pause: breath register 2 pause value
         """
         if fade_in is None and fade_out is None:
-            return self._register(_CONFIG_BANK, _BREATH2_REGISTER, 0)
-        elif fade_in is None:
+            self._register(_CONFIG_BANK, _BREATH2_REGISTER, 0)
+            return 
+        if fade_in is None:
             fade_in = fade_out
         elif fade_out is None:
             fade_out = fade_in

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -190,7 +190,7 @@ class IS31FL3731:
         self._register(_CONFIG_BANK, _AUTOPLAY2_REGISTER, delay % 64)
         self._mode(_AUTOPLAY_MODE | self._frame)
 
-    def fade(self, fade_in=None, fade_out=None, pause=0):
+    def fade(self, fade_in=None, fade_out=None, pause=26):
         """
         Start and stop the fade feature.  If both fade_in and fade_out are None (the
         default), the breath feature is used for fading.  if fade_in is None, then
@@ -201,7 +201,7 @@ class IS31FL3731:
         :param pause: breath register 2 pause value
         """
         if fade_in is None and fade_out is None:
-            self._register(_CONFIG_BANK, _BREATH2_REGISTER, 0)
+            return self._register(_CONFIG_BANK, _BREATH2_REGISTER, 0)
         elif fade_in is None:
             fade_in = fade_out
         elif fade_out is None:

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -202,7 +202,7 @@ class IS31FL3731:
         """
         if fade_in is None and fade_out is None:
             self._register(_CONFIG_BANK, _BREATH2_REGISTER, 0)
-            return 
+            return
         if fade_in is None:
             fade_in = fade_out
         elif fade_out is None:

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -190,7 +190,7 @@ class IS31FL3731:
         self._register(_CONFIG_BANK, _AUTOPLAY2_REGISTER, delay % 64)
         self._mode(_AUTOPLAY_MODE | self._frame)
 
-    def fade(self, fade_in=None, fade_out=None, pause=26):
+    def fade(self, fade_in=None, fade_out=None, pause=0):
         """
         Start and stop the fade feature.  If both fade_in and fade_out are None (the
         default), the breath feature is used for fading.  if fade_in is None, then
@@ -207,9 +207,13 @@ class IS31FL3731:
             fade_in = fade_out
         elif fade_out is None:
             fade_out = fade_in
-        fade_in = int(math.log(fade_in / 26, 2))
-        fade_out = int(math.log(fade_out / 26, 2))
-        pause = int(math.log(pause / 26, 2))
+
+        if fade_in != 0:
+            fade_in = int(math.log(fade_in / 26, 2))
+        if fade_out != 0:
+            fade_out = int(math.log(fade_out / 26, 2))
+        if pause != 0:
+            pause = int(math.log(pause / 26, 2))
         if not 0 <= fade_in <= 7:
             raise ValueError("Fade in out of range")
         if not 0 <= fade_out <= 7:

--- a/examples/is31fl3731_ledshim_fade.py
+++ b/examples/is31fl3731_ledshim_fade.py
@@ -22,4 +22,3 @@ try:
         time.sleep(10)
 except KeyboardInterrupt:
     display.sleep(True)
-    exit

--- a/examples/is31fl3731_ledshim_fade.py
+++ b/examples/is31fl3731_ledshim_fade.py
@@ -20,6 +20,6 @@ display.fade(fade_in=104, pause=250)
 try:
     while True:
         time.sleep(10)
-except:
+except KeyboardInterrupt:
     display.sleep(True)
     exit

--- a/examples/is31fl3731_ledshim_fade.py
+++ b/examples/is31fl3731_ledshim_fade.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import time
+import board
+import busio
+from adafruit_is31fl3731.led_shim import LedShim as Display
+
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# initial display if you are using Pimoroni LED SHIM
+display = Display(i2c)
+
+y = 1
+for x in range(28):
+    display.pixel(x, y, 255)
+
+
+try:
+    display.fade(fade_in=100, pause=26)
+    while True:
+        time.sleep(1)
+except:
+    display.sleep(True)
+    exit

--- a/examples/is31fl3731_ledshim_fade.py
+++ b/examples/is31fl3731_ledshim_fade.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 E. A. Graham, Jr.
 # SPDX-License-Identifier: MIT
 
 import time

--- a/examples/is31fl3731_ledshim_fade.py
+++ b/examples/is31fl3731_ledshim_fade.py
@@ -15,11 +15,11 @@ y = 1
 for x in range(28):
     display.pixel(x, y, 255)
 
+display.fade(fade_in=104, pause=250)
 
 try:
-    display.fade(fade_in=100, pause=26)
     while True:
-        time.sleep(1)
+        time.sleep(10)
 except:
     display.sleep(True)
     exit


### PR DESCRIPTION
Fixes #52 with a return when both fade params are `None`. Also updates
the default pause value to not throw math errors on `0`.

(Added another `venv` variation to the .gitignore)

Note: the values in the docstrings do not appear to be correct; the functionality doesn't
seem to be supported on the shim or this isn't working as expected