### PR TITLE
Add Rotation and Typing

### DIFF
--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -61,7 +61,7 @@ try:
     from PIL import Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, WritableBuffer
+        from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError as e:
     pass
 
@@ -116,9 +116,7 @@ class IS31FL3731:
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(
-        self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None
-    ) -> Optional[WriteableBuffer]:
+    def _i2c_read_reg(self, result: WriteableBuffer, reg: Optional[int] = None) -> None:
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.
@@ -127,14 +125,12 @@ class IS31FL3731:
             return result
         return None
 
-    def _i2c_write_reg(
-        self, reg: Optional[int] = None, data: Optional[ReadableBuffer] = None
-    ) -> None:
+    def _i2c_write_reg(self, data: ReadableBuffer, reg: Optional[int] = None) -> None:
         # Write a contiguous block of data (bytearray) starting at the
         # specified I2C register address (register passed as argument).
         self._i2c_write_block(bytes([reg]) + data)
 
-    def _i2c_write_block(self, data: Optional[ReadableBuffer]) -> None:
+    def _i2c_write_block(self, data: ReadableBuffer) -> None:
         # Write a buffer of data (byte array) to the specified I2C register
         # address.
         with self.i2c_device as i2c:
@@ -439,9 +435,7 @@ class IS31FL3731:
         imwidth, imheight = img.size
         if imwidth != self.width or imheight != self.height:
             raise ValueError(
-                "Image must be same dimensions as display ({0}x{1}).".format(
-                    self.width, self.height
-                )
+                f"Image must be same dimensions as display {self.width}x{self.height}"
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.load()

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -59,9 +59,7 @@ import busio
 try:
     from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
     from PIL import Image
-
-    if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, WriteableBuffer
+    from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -61,7 +61,7 @@ try:
     from PIL import Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
+        from circuitpython_typing import ReadableBuffer, WritableBuffer
 except ImportError as e:
     pass
 
@@ -116,7 +116,9 @@ class IS31FL3731:
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None):
+    def _i2c_read_reg(
+        self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None
+    ):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -57,13 +57,14 @@ from adafruit_bus_device.i2c_device import I2CDevice
 import busio
 
 try:
-    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable, ReadableBuffer
+    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
     from PIL import Image
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
 except ImportError as e:
     pass
+
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3731.git"

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -57,19 +57,22 @@ from adafruit_bus_device.i2c_device import I2CDevice
 try:
     import typing
     import busio
+    from circuitpython_typing import TypeAlias, Union
+    from circuitpython_typing import (
+        WriteableBuffer,
+        ReadableBuffer,
+    )  # Import ReadableBuffer here
+
     from typing import (
         TYPE_CHECKING,
         List,
         Tuple,
         Optional,
         Iterable,
-        ReadableBuffer,
-        WriteableBuffer,
     )
+
     from PIL import Image
 
-    if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError as e:
     pass
 
@@ -124,7 +127,7 @@ class IS31FL3731:
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(self, result: WriteableBuffer, reg: Optional[int] = None) -> None:
+    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[int] = None):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.
@@ -133,12 +136,14 @@ class IS31FL3731:
             return result
         return None
 
-    def _i2c_write_reg(self, data: ReadableBuffer, reg: Optional[int] = None) -> None:
+    def _i2c_write_reg(
+        self, reg: Optional[int] = None, data: Optional[ReadableBuffer] = None
+    ) -> None:
         # Write a contiguous block of data (bytearray) starting at the
         # specified I2C register address (register passed as argument).
         self._i2c_write_block(bytes([reg]) + data)
 
-    def _i2c_write_block(self, data: ReadableBuffer) -> None:
+    def _i2c_write_block(self, data: Optional[ReadableBuffer]) -> None:
         # Write a buffer of data (byte array) to the specified I2C register
         # address.
         with self.i2c_device as i2c:
@@ -443,7 +448,9 @@ class IS31FL3731:
         imwidth, imheight = img.size
         if imwidth != self.width or imheight != self.height:
             raise ValueError(
-                f"Image must be same dimensions as display {self.width}x{self.height}"
+                "Image must be same dimensions as display ({0}x{1}).".format(
+                    self.width, self.height
+                )
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.load()

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -59,7 +59,7 @@ try:
     from typing import TYPE_CHECKING, List, Tuple
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, Optional
+        from circuitpython_typing import ReadableBuffer, Optional, Iterable
         import busio
 except ImportError as e:
     pass

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -55,6 +55,7 @@ from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
 import busio
+
 try:
     from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable, ReadableBuffer
     from PIL import Image
@@ -371,7 +372,7 @@ class IS31FL3731:
         :param frame: int the frame to set the pixel, default 0
         :param rotate: int display rotation (0, 90, 180, 270)
         """
-        #pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches
 
         if rotate not in (0, 90, 180, 270):
             raise ValueError("Rotation must be 0, 90, 180, or 270 degrees")

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -59,7 +59,9 @@ import busio
 try:
     from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
     from PIL import Image
-    from circuitpython_typing import ReadableBuffer
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import CompletelyMadeUpTest
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -118,7 +118,7 @@ class IS31FL3731:
 
     def _i2c_read_reg(
         self, reg: Optional[int] = None, result: Optional[ReadableBuffer] = None
-    ) -> None:
+    ):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -117,7 +117,7 @@ class IS31FL3731:
         self._init(frames=frames)
 
     def _i2c_read_reg(
-        self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None
+        self, reg: Optional[int] = None, result: WritableBuffer[bytearray] = None
     ):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -56,10 +56,11 @@ from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
 try:
-    from typing import TYPE_CHECKING, List, Tuple
+    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
+    from PIL import Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, Optional, Iterable
+        from circuitpython_typing import ReadableBuffer
         import busio
 except ImportError as e:
     pass

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -111,7 +111,7 @@ class IS31FL3731:
 
     :param ~busio.I2C i2c: the connected i2c bus i2c_device
     :param int address: the device address; defaults to 0x74
-    :param int frames: static 0 or animation frames (0-7)
+    :param Iterable frames: list of frame indexes to use. int's 0-7.
     """
 
     width: int = 16
@@ -120,14 +120,16 @@ class IS31FL3731:
     def __init__(
         self,
         i2c: busio.I2C,
-        frames: Optional[int] = None,
+        frames: Optional[Iterable] = None,
         address: int = 0x74,
     ):
         self.i2c_device = I2CDevice(i2c, address)
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[int] = None):
+    def _i2c_read_reg(
+        self, reg: Optional[int] = None, result: Optional[WriteableBuffer] = None
+    ) -> Optional[WriteableBuffer]:
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.
@@ -190,13 +192,13 @@ class IS31FL3731:
         self._frame = 0  # To match config bytes above
         self.sleep(False)
 
-    def reset(self):
+    def reset(self) -> None:
         """Kill the display for 10MS"""
         self.sleep(True)
         time.sleep(0.01)  # 10 MS pause to reset.
         self.sleep(False)
 
-    def sleep(self, value):
+    def sleep(self, value: bool) -> Optional[int]:
         """
         Set the Software Shutdown Register bit
 
@@ -206,10 +208,10 @@ class IS31FL3731:
 
     def autoplay(
         self,
-        delay: Optional[int] = None,
-        loops: Optional[Iterable] = None,
-        frames: Optional[int] = None,
-    ) -> int:
+        delay: int = 0,
+        loops: int = 0,
+        frames: int = 0,
+    ) -> None:
         """
         Start autoplay
 
@@ -235,7 +237,7 @@ class IS31FL3731:
         self,
         fade_in: Optional[int] = None,
         fade_out: Optional[int] = None,
-        pause: Optional[int] = None,
+        pause: int = 0,
     ) -> int:
         """
         Start and stop the fade feature.  If both fade_in and fade_out are None (the
@@ -314,7 +316,7 @@ class IS31FL3731:
         )
         self._mode(_AUDIOPLAY_MODE)
 
-    def blink(self, rate: Optional[int]) -> Optional[int]:
+    def blink(self, rate: Optional[int] = None) -> Optional[int]:
         """Updates the blink register"""
         # pylint: disable=no-else-return
         # This needs to be refactored when it can be tested
@@ -435,7 +437,9 @@ class IS31FL3731:
 
     # pylint: enable-msg=too-many-arguments
 
-    def image(self, img: Optional[str], frame: Optional[int], blink: bool = False):
+    def image(
+        self, img: Image, frame: Optional[int] = None, blink: bool = False
+    ) -> None:
         """Set buffer to value of Python Imaging Library image.  The image should
         be in 8-bit mode (L) and a size equal to the display size.
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -116,9 +116,7 @@ class IS31FL3731:
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(
-        self, reg: Optional[int] = None, result: Optional[ReadableBuffer] = None
-    ):
+    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[int] = None):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -117,8 +117,8 @@ class IS31FL3731:
         self._init(frames=frames)
 
     def _i2c_read_reg(
-        self, reg: Optional[int] = None, result: WritableBuffer[bytearray] = None
-    ):
+        self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None
+    ) -> Optional[WriteableBuffer]:
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -47,7 +47,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
-
 # imports
 import math
 import time
@@ -55,13 +54,13 @@ from micropython import const
 
 from adafruit_bus_device.i2c_device import I2CDevice
 
+import busio
 try:
-    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
+    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable, ReadableBuffer
     from PIL import Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
-        import busio
+        import circuitpython_typing
 except ImportError as e:
     pass
 
@@ -372,6 +371,7 @@ class IS31FL3731:
         :param frame: int the frame to set the pixel, default 0
         :param rotate: int display rotation (0, 90, 180, 270)
         """
+        #pylint: disable=too-many-branches
 
         if rotate not in (0, 90, 180, 270):
             raise ValueError("Rotation must be 0, 90, 180, or 270 degrees")

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -61,7 +61,7 @@ try:
     from PIL import Image
 
     if TYPE_CHECKING:
-        import circuitpython_typing
+        from circuitpython_typing import ReadableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -55,11 +55,11 @@ from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
 import busio
+from circuitpython_typing import ReadableBuffer, WriteableBuffer
 
 try:
     from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
     from PIL import Image
-    from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -59,9 +59,7 @@ import busio
 try:
     from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
     from PIL import Image
-
-    if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
+    from circuitpython_typing import ReadableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -118,7 +118,7 @@ class IS31FL3731:
 
     def _i2c_read_reg(
         self, reg: Optional[int] = None, result: Optional[ReadableBuffer] = None
-    ) -> Optional[ReadableBuffer]:
+    ) -> None:
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -116,7 +116,7 @@ class IS31FL3731:
         self._frame = None
         self._init(frames=frames)
 
-    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[int] = None):
+    def _i2c_read_reg(self, reg: Optional[int] = None, result: Optional[WritableBuffer] = None):
         # Read a buffer of data from the specified 8-bit I2C register address.
         # The provided result parameter will be filled to capacity with bytes
         # of data read from the register.

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -59,7 +59,7 @@ try:
     from typing import TYPE_CHECKING, List, Tuple
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
+        from circuitpython_typing import ReadableBuffer, Optional
         import busio
 except ImportError as e:
     pass

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -54,12 +54,22 @@ from micropython import const
 
 from adafruit_bus_device.i2c_device import I2CDevice
 
-import busio
-from circuitpython_typing import ReadableBuffer, WriteableBuffer
-
 try:
-    from typing import TYPE_CHECKING, List, Tuple, Optional, Iterable
+    import typing
+    import busio
+    from typing import (
+        TYPE_CHECKING,
+        List,
+        Tuple,
+        Optional,
+        Iterable,
+        ReadableBuffer,
+        WriteableBuffer,
+    )
     from PIL import Image
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -104,7 +104,7 @@ class IS31FL3731:
     width: int = 16
     height: int = 9
 
-    def __init__(self, i2c: busio.I2C, address: int = 0x74, frames: int = None) -> None:
+    def __init__(self, i2c: None, address: int = 0x74, frames: int = None) -> None:
         self.i2c_device = I2CDevice(i2c, address)
         self._frame = None
         self._init(frames=frames)
@@ -325,7 +325,7 @@ class IS31FL3731:
         """Calulate the offset into the device array for x,y pixel"""
         return x + y * 16
 
-    # pylint: disable-msg=too-many-arguments
+    # pylint: disable-msg=too-many-arguments, too-many-branches
     def pixel(
         self,
         x: int,
@@ -350,27 +350,27 @@ class IS31FL3731:
             raise ValueError("Rotation must be 0, 90, 180, or 270 degrees")
 
         if rotate == 0:
-            if not 0 <= x <= self.width:
-                return None
-            if not 0 <= y <= self.height:
+            check_x = 0 <= x <= self.width
+            check_y = 0 <= y <= self.height
+            if not (check_x and check_y):
                 return None
             pixel = self.pixel_addr(x, y)
         elif rotate == 90:
-            if not 0 <= y <= self.width:
-                return None
-            if not 0 <= x <= self.height:
+            check_x = 0 <= y <= self.width
+            check_y = 0 <= x <= self.height
+            if not (check_x and check_y):
                 return None
             pixel = self.pixel_addr(y, self.height - x - 1)
         elif rotate == 180:
-            if not 0 <= x <= self.width:
-                return None
-            if not 0 <= y <= self.height:
+            check_x = 0 <= x <= self.width
+            check_y = 0 <= y <= self.height
+            if not (check_x and check_y):
                 return None
             pixel = self.pixel_addr(self.width - x - 1, self.height - y - 1)
         elif rotate == 270:
-            if not 0 <= y <= self.width:
-                return None
-            if not 0 <= x <= self.height:
+            check_x = 0 <= y <= self.width
+            check_y = 0 <= x <= self.height
+            if not (check_x and check_y):
                 return None
             pixel = self.pixel_addr(self.width - y - 1, x)
 
@@ -410,9 +410,7 @@ class IS31FL3731:
         imwidth, imheight = img.size
         if imwidth != self.width or imheight != self.height:
             raise ValueError(
-                "Image must be same dimensions as display ({0}x{1}).".format(
-                    self.width, self.height
-                )
+                f"Image must be same dimensions as display {self.width}x{self.height}"
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.load()

--- a/adafruit_is31fl3731/__init__.py
+++ b/adafruit_is31fl3731/__init__.py
@@ -61,7 +61,7 @@ try:
     from PIL import Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import CompletelyMadeUpTest
+        from circuitpython_typing import ReadableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -28,7 +28,9 @@ Implementation Notes
 
 # imports
 from . import IS31FL3731
-from .pil import Image  # Import Image from the pil module
+from .circuitpython_typing.pil import (
+    Image,
+)  # Import Image from the pil module within circuitpython_typing
 
 try:
     from typing import TYPE_CHECKING, Optional

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -27,8 +27,6 @@ Implementation Notes
 """
 
 # imports
-from . import IS31FL3731
-
 try:
     from typing import TYPE_CHECKING, Optional
 
@@ -41,6 +39,8 @@ try:
         from PIL import Image
 except ImportError as e:
     pass
+
+from . import IS31FL3731
 
 
 class Matrix(IS31FL3731):

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -33,7 +33,7 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
+        from circuitpython_typing import ReadableBuffer, Optional
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -32,8 +32,11 @@ from . import IS31FL3731
 try:
     from typing import Optional
 
-    # Define a placeholder for Image if it's not available
-    IMAGE = None
+    try:
+        from PIL import Image
+    except ImportError:
+        # placeholder if PIL unavailable
+        Image = None
 except ImportError as e:
     pass
 
@@ -56,7 +59,7 @@ class Matrix(IS31FL3731):
     # for animation. Buffering the full matrix for a quick write is not a
     # memory concern here, as by definition this method is used with PIL
     # images; we're not running on a RAM-constrained microcontroller.
-    def image(self, img: Optional[IMAGE], frame: Optional[int], blink: bool = False):
+    def image(self, img: Image, frame: Optional[int] = None, blink: bool = False):
         """Set buffer to value of Python Imaging Library image.
         The image should be in 8-bit mode (L) and a size equal to the
         display size.

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -30,7 +30,7 @@ Implementation Notes
 from . import IS31FL3731
 
 try:
-    from typing import TYPE_CHECKING, List, Tuple
+    from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
@@ -69,13 +69,11 @@ class Matrix(IS31FL3731):
             raise ValueError("Image must be in mode L.")
         if img.size[0] != self.width or img.size[1] != self.height:
             raise ValueError(
-                "Image must be same dimensions as display ({0}x{1}).".format(
-                    self.width, self.height
-                )
+                f"Image must be same dimensions as display {self.width}x{self.height}"
             )
 
         # Frame-select and then write pixel data in one big operation
-        if frame is not 0:
+        if frame != 0:
             self._bank(frame)
         # We can safely reduce the image to a "flat" byte sequence because
         # the matrix layout is known linear; no need to go through a 2D

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -27,20 +27,16 @@ Implementation Notes
 """
 
 # imports
+from . import IS31FL3731
+from .pil import Image  # Import Image from the pil module
+
 try:
     from typing import TYPE_CHECKING, Optional
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
-
-    import sys
-
-    if sys.platform == "linux":
-        from PIL import Image
 except ImportError as e:
     pass
-
-from . import IS31FL3731
 
 
 class Matrix(IS31FL3731):

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -28,15 +28,10 @@ Implementation Notes
 
 # imports
 from . import IS31FL3731
-from .circuitpython_typing.pil import (
-    Image,
-)  # Import Image from the pil module within circuitpython_typing
 
 try:
-    from typing import TYPE_CHECKING, Optional
-
-    if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer
+    from typing import Optional
+    from circuitpython_typing import Image
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -29,15 +29,23 @@ Implementation Notes
 # imports
 from . import IS31FL3731
 
+try:
+    from typing import TYPE_CHECKING, List, Tuple
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+except ImportError as e:
+    pass
+
 
 class Matrix(IS31FL3731):
-    """Supports the Charlieplexed feather wing"""
+    """Charlieplexed Featherwing & IS31FL3731 I2C Modules"""
 
-    width = 16
-    height = 9
+    width: int = 16
+    height: int = 9
 
     @staticmethod
-    def pixel_addr(x, y):
+    def pixel_addr(x: int, y: int) -> int:
         """Calulate the offset into the device array for x,y pixel"""
         return x + y * 16
 
@@ -48,7 +56,7 @@ class Matrix(IS31FL3731):
     # for animation. Buffering the full matrix for a quick write is not a
     # memory concern here, as by definition this method is used with PIL
     # images; we're not running on a RAM-constrained microcontroller.
-    def image(self, img, blink=None, frame=None):
+    def image(self, img: str = None, blink: bool = False, frame: int = 0):
         """Set buffer to value of Python Imaging Library image.
         The image should be in 8-bit mode (L) and a size equal to the
         display size.
@@ -67,13 +75,13 @@ class Matrix(IS31FL3731):
             )
 
         # Frame-select and then write pixel data in one big operation
-        if frame is not None:
+        if frame is not 0:
             self._bank(frame)
         # We can safely reduce the image to a "flat" byte sequence because
         # the matrix layout is known linear; no need to go through a 2D
         # pixel array or invoke pixel_addr().
         self._i2c_write_block(bytes([0x24]) + img.tobytes())
         # Set or clear blink state if requested, for all pixels at once
-        if blink is not None:
+        if blink:
             # 0x12 is _BLINK_OFFSET in __init__.py
             self._i2c_write_block(bytes([0x12] + [1 if blink else 0] * 18))

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -30,10 +30,15 @@ Implementation Notes
 from . import IS31FL3731
 
 try:
-    from typing import TYPE_CHECKING, Optional, Image
+    from typing import TYPE_CHECKING, Optional
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
+
+    import sys
+
+    if sys.platform == "linux":
+        from PIL import Image
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -33,7 +33,7 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, Optional
+        from circuitpython_typing import ReadableBuffer, Optional, Image
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -30,10 +30,10 @@ Implementation Notes
 from . import IS31FL3731
 
 try:
-    from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional, Image
 
     if TYPE_CHECKING:
-        from circuitpython_typing import ReadableBuffer, Optional, Image
+        from circuitpython_typing import ReadableBuffer
 except ImportError as e:
     pass
 

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -56,7 +56,7 @@ class Matrix(IS31FL3731):
     # for animation. Buffering the full matrix for a quick write is not a
     # memory concern here, as by definition this method is used with PIL
     # images; we're not running on a RAM-constrained microcontroller.
-    def image(self, img: str = None, blink: bool = False, frame: int = 0):
+    def image(self, img: Optional[Image], frame: Optional[int], blink: bool = False):
         """Set buffer to value of Python Imaging Library image.
         The image should be in 8-bit mode (L) and a size equal to the
         display size.
@@ -73,7 +73,7 @@ class Matrix(IS31FL3731):
             )
 
         # Frame-select and then write pixel data in one big operation
-        if frame != 0:
+        if frame is not None:
             self._bank(frame)
         # We can safely reduce the image to a "flat" byte sequence because
         # the matrix layout is known linear; no need to go through a 2D

--- a/adafruit_is31fl3731/matrix.py
+++ b/adafruit_is31fl3731/matrix.py
@@ -31,7 +31,9 @@ from . import IS31FL3731
 
 try:
     from typing import Optional
-    from circuitpython_typing import Image
+
+    # Define a placeholder for Image if it's not available
+    IMAGE = None
 except ImportError as e:
     pass
 
@@ -54,7 +56,7 @@ class Matrix(IS31FL3731):
     # for animation. Buffering the full matrix for a quick write is not a
     # memory concern here, as by definition this method is used with PIL
     # images; we're not running on a RAM-constrained microcontroller.
-    def image(self, img: Optional[Image], frame: Optional[int], blink: bool = False):
+    def image(self, img: Optional[IMAGE], frame: Optional[int], blink: bool = False):
         """Set buffer to value of Python Imaging Library image.
         The image should be in 8-bit mode (L) and a size equal to the
         display size.

--- a/examples/is31fl3731_16x9_charlieplexed_pwm.py
+++ b/examples/is31fl3731_16x9_charlieplexed_pwm.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2024 DJDevon3
+# SPDX-License-Identifier: MIT
+""" Adafruit 16x9 Charlieplexed PWM LED Matrix Example """
+
+import board
+import adafruit_framebuf
+
+from adafruit_is31fl3731.matrix import Matrix as Display
+
+# Uncomment for Pi Pico
+# import busio
+# i2c = busio.I2C(board.GP21, board.GP20)
+
+i2c = board.STEMMA_I2C()
+display = Display(i2c, address=0x74)
+
+pixel_rotation = 90  # display rotation (0,90,180,270)
+pixel_brightness = 20  # values (0-255)
+pixel_blink = False  # blink entire display
+
+text_to_show = "Hello World!"  # Scrolling marquee text
+
+print(f"Display Dimensions: {display.width}x{display.height}")
+print(f"Text: {text_to_show}")
+
+# Create a framebuffer for our display
+buf = bytearray(32)  # 2 bytes tall x 16 wide = 32 bytes (9 bits is 2 bytes)
+buffer = adafruit_framebuf.FrameBuffer(
+    buf, display.width, display.height, adafruit_framebuf.MVLSB
+)
+
+frame = 0  # start with frame 0
+while True:
+    # Looping marquee
+    for i in range(len(text_to_show) * 9):
+        buffer.fill(0)
+        buffer.text(text_to_show, -i + display.width, 0, color=1)
+        display.frame(frame, show=False)
+        display.fill(0)
+        for x in range(display.width):
+            # using the FrameBuffer text result
+            bite = buf[x]
+            for y in range(display.height):
+                bit = 1 << y & bite
+                # if bit > 0 then set the pixel brightness
+                if bit:
+                    display.pixel(
+                        x, y, pixel_brightness, blink=pixel_blink, rotate=pixel_rotation
+                    )

--- a/examples/is31fl3731_16x9_charlieplexed_pwm.py
+++ b/examples/is31fl3731_16x9_charlieplexed_pwm.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 DJDevon3
 # SPDX-License-Identifier: MIT
 """ Adafruit 16x9 Charlieplexed PWM LED Matrix Example """
-
+# pylint: disable=import-error
 import board
 import adafruit_framebuf
 
@@ -14,14 +14,14 @@ from adafruit_is31fl3731.matrix import Matrix as Display
 i2c = board.STEMMA_I2C()
 display = Display(i2c, address=0x74)
 
-pixel_rotation = 90  # display rotation (0,90,180,270)
-pixel_brightness = 20  # values (0-255)
-pixel_blink = False  # blink entire display
+PIXEL_ROTATION = 0  # display rotation (0,90,180,270)
+PIXEL_BRIGHTNESS = 20  # values (0-255)
+PIXEL_BLINK = False  # blink entire display
 
-text_to_show = "Hello World!"  # Scrolling marquee text
+TEXT = "Hello World!"  # Scrolling marquee text
 
 print(f"Display Dimensions: {display.width}x{display.height}")
-print(f"Text: {text_to_show}")
+print(f"Text: {TEXT}")
 
 # Create a framebuffer for our display
 buf = bytearray(32)  # 2 bytes tall x 16 wide = 32 bytes (9 bits is 2 bytes)
@@ -29,13 +29,13 @@ buffer = adafruit_framebuf.FrameBuffer(
     buf, display.width, display.height, adafruit_framebuf.MVLSB
 )
 
-frame = 0  # start with frame 0
+FRAME = 0  # start with frame 0
 while True:
     # Looping marquee
-    for i in range(len(text_to_show) * 9):
+    for i in range(len(TEXT) * 9):
         buffer.fill(0)
-        buffer.text(text_to_show, -i + display.width, 0, color=1)
-        display.frame(frame, show=False)
+        buffer.text(TEXT, -i + display.width, 0, color=1)
+        display.frame(FRAME, show=False)
         display.fill(0)
         for x in range(display.width):
             # using the FrameBuffer text result
@@ -45,5 +45,5 @@ while True:
                 # if bit > 0 then set the pixel brightness
                 if bit:
                     display.pixel(
-                        x, y, pixel_brightness, blink=pixel_blink, rotate=pixel_rotation
+                        x, y, PIXEL_BRIGHTNESS, blink=PIXEL_BLINK, rotate=PIXEL_ROTATION
                     )

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 adafruit-circuitpython-framebuf
+pillow


### PR DESCRIPTION
Added new feature: ability to rotate display 0,90,180,270.  

This will be particularly useful to arrange multiple charlieplexed matrixes together in any orientation for chaining.  I don't think chaining multiple into 1 matrix is currently supported but it's a step in the right direction.

Added 16x9 charlieplex example that includes the new rotation feature.

"attempted" to add typing annotations... expect some to be wrong and that's ok, an attempt was made. i did not attempt to type every file.  want to be sure i can do at least 1 correctly first then will do the other examples.

Rotation = 0 (hard to photograph because it's a scrolling marquee)
![IMG_1487](https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3731/assets/49322231/3e3e9978-cbb3-45f8-a31d-7e1c03675dc6)

Rotation = 90
![IMG_1488](https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3731/assets/49322231/5541093b-ff1a-4eea-8ada-3a6b5b08455c)
